### PR TITLE
Stop building books

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.rust-embedded.org

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -32,22 +32,6 @@ main() {
     rustdoc --markdown-css rust.css --markdown-no-toc index.md
     rustdoc --markdown-css rust.css faq.md
 
-    # build books
-    local books=(
-        book
-        discovery
-        embedonomicon
-    )
-
-    local tmpdir=$(mktemp -d)
-    for book in "${books[@]}"; do
-        git clone https://github.com/rust-embedded/$book $tmpdir/$book
-        ( cd $tmpdir/$book && mdbook build )
-        mv $tmpdir/$book/book doc/$book
-    done
-
-    rm -rf $tmpdir
-
     # check links
     # FIXME(rust-lang-nursery/mdbook#789) remove `--ignore-url` when that bug is fixed
     linkchecker --ignore-url "print.html" doc

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ before.
 peripherals, sensors and bare metal programming through a series of small, fun
 projects that you'll develop in Rust.
 
-[discovery]: discovery/index.html
+[discovery]: https://docs.rust-embedded.org/discovery/index.html
 
 # Learn embedded Rust
 
@@ -40,7 +40,7 @@ book][book] will get you up to speed with embedded Rust development and then
 teach you how to effectively use the language (AKA patterns) to build more
 correct embedded software.
 
-[book]: book/index.html
+[book]: https://docs.rust-embedded.org/book/index.html
 
 ## Operating System development tutorials in Rust on the Raspberry Pi
 
@@ -81,4 +81,4 @@ of linker scripts, symbols and ABIs. You'll learn about linker script and the
 language features that let you control the ABI of crates by creating a `no_std`
 program for the ARM Cortex-M architecture from scratch.
 
-[The embedonomicon]:embedonomicon/index.html
+[The embedonomicon]: https://docs.rust-embedded.org/embedonomicon/index.html


### PR DESCRIPTION
Since this repo now sets the URL for the org's github pages, the book repositories are now automatically published to the relevant docs.rust-embedded.org URL, and this repo no longer needs to generate them.

Also remove the ineffective CNAME file; we instead specify the CNAME in ci/after-success.sh.