### PR TITLE
Fix which sections of binary belong to Flash/ROM vs RAM

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -247,7 +247,7 @@ ROM; `.bss` and `.data` will occupy RAM; `.debug_*`, `.ARM.attributes` and
 `.comments` can be ignored as they won't be loaded into the target device
 memory. For the other sections you'll have to check your dependencies' docs.
 
-In these examples the program will occupy `2008` bytes of Flash.
+In this example the uploaded software will occupy `2008` bytes of Flash.
 
 Note that most (all?) runtime crates, like `cortex-m-rt`, will check at link
 time that the program fits in the target device memory. If it doesn't fit you'll


### PR DESCRIPTION
Supporting information for my fix is here https://docs.rs/cortex-m-rt/latest/cortex_m_rt/#sections-size

1. `.data` does not belong to Flash 
    * So I removed this from Flash description.
2. `vector_table` does belong to Flash &mdash;in this arch at least (see link above).
    * So I added it to the Flash Description.

You don't get 2008 bytes otherwise, but now it does add up to 2008.

cc: @adamgreig since it's last person working in this repo.