### PR TITLE
removed status requirement to try to get bors going

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,4 +1,4 @@
 block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
-status = ["build"]
+#status = ["build"]


### PR DESCRIPTION
It looks like there might be a `bors.toml` issue. Attempting a quick fix.